### PR TITLE
Replace jQuery with HTTP package

### DIFF
--- a/lib/client/kadira.js
+++ b/lib/client/kadira.js
@@ -72,8 +72,3 @@ function initialize (options) {
     Zone.collectAllStacks = Kadira.options.collectAllStacks;
   }
 }
-
-// patch jQuery ajax transport to use IE8/IE9 XDR if necessary
-if(window.XDomainRequest) {
-  fixInternetExplorerXDR();
-}

--- a/lib/client/utils.js
+++ b/lib/client/utils.js
@@ -101,38 +101,33 @@ checkSizeAndPickFields = function(maxFieldSize) {
   }
 }
 
-/**
- * IE8 and IE9 does not support CORS with the usual XMLHttpRequest object
- * If XDomainRequest exists, use it to send errors.
- * XDR can POST data to HTTPS endpoints only if current page uses HTTPS
- */
-fixInternetExplorerXDR = function () {
+httpRequest = function (method, url, options, callback) {
+  /**
+   * IE8 and IE9 does not support CORS with the usual XMLHttpRequest object
+   * If XDomainRequest exists, use it to send errors.
+   * XDR can POST data to HTTPS endpoints only if current page uses HTTPS
+   */
   if (window.XDomainRequest) {
-    $.ajaxTransport(function(s) {
-      return {
-        send: function (headers, callback) {
-          var xdr = new XDomainRequest();
-          var data = s.data || null;
-          var url = matchPageProtocol(s.url);
+    var xdr = new XDomainRequest();
+    url = matchPageProtocol(url);
 
-          xdr.onload = function () {
-            var headers = {'Content-Type': xdr.contentType};
-            callback(200, 'OK', {text: xdr.responseText}, headers);
-          }
+    xdr.onload = function () {
+      var headers = { 'Content-Type': xdr.contentType };
+      callback(null, { content: xdr.responseText, headers: headers });
+    }
 
-          xdr.onerror = function () {
-            callback(404);
-          }
+    xdr.onerror = function () {
+      callback({ statusCode: 404 });
+    }
 
-          xdr.open(s.type, url);
-          xdr.send(data);
-        }
-      };
-    });
+    xdr.open(method, url);
+    xdr.send(options.content || null);
+
+    function matchPageProtocol (endpoint) {
+      var withoutProtocol = endpoint.substr(endpoint.indexOf(':') + 1);
+      return window.location.protocol + withoutProtocol;
+    }
+  } else {
+    HTTP.call(method, url, options, callback);
   }
-
-  function matchPageProtocol (endpoint) {
-    var withoutProtocol = endpoint.substr(endpoint.indexOf(':') + 1);
-    return window.location.protocol + withoutProtocol;
-  }
-}
+};

--- a/lib/common/send.js
+++ b/lib/common/send.js
@@ -43,18 +43,12 @@ Kadira._getSendFunction = function() {
 };
 
 Kadira._clientSend = function (endpoint, payload, callback) {
-  $.ajax({
-    type: 'POST',
-    url: endpoint,
-    contentType: 'application/json',
-    data: JSON.stringify(payload),
-    error: function(err) {
-      callback(err);
+  httpRequest('POST', endpoint, {
+    headers: {
+      contentType: 'application/json'
     },
-    success: function(data) {
-      callback(null, data, 200);
-    }
-  }); 
+    content: JSON.stringify(payload)
+  }, callback);
 }
 
 Kadira._serverSend = function (endpoint, payload, callback) {
@@ -72,7 +66,7 @@ Kadira._serverSend = function (endpoint, payload, callback) {
         callback(null, content, res.statusCode);
       } else {
         callback(err);
-      }  
+      }
     });
   }).run();
 }

--- a/lib/ntp.js
+++ b/lib/ntp.js
@@ -108,20 +108,18 @@ Ntp.prototype.getServerTime = function(callback) {
         if(err) {
           callback(err);
         } else {
-          var serverTime = parseInt(res.content)
+          var serverTime = parseInt(res.content);
           callback(null, serverTime);
         }
       });
     }).run();
   } else {
-    $.ajax({
-      type: 'GET',
-      url: self.endpoint,
-      success: function(serverTime) {
-        callback(null, parseInt(serverTime));
-      },
-      error: function(err) {
+    httpRequest('GET', self.endpoint, function(err, res) {
+      if (err) {
         callback(err);
+      } else {
+        var serverTime = parseInt(res.content);
+        callback(null, serverTime);
       }
     });
   }

--- a/package.js
+++ b/package.js
@@ -95,7 +95,7 @@ function configurePackage(api) {
     'minimongo', 'livedata', 'mongo-livedata', 'ejson', 'ddp-common',
     'underscore', 'http', 'email', 'random'
   ], ['server']);
-  api.use(['underscore', 'random', 'jquery', 'localstorage'], ['client']);
+  api.use(['underscore', 'random', 'http', 'localstorage'], ['client']);
 
   // common before
   api.add_files([


### PR DESCRIPTION
I moved over this [PR](https://github.com/meteorhacks/kadira/pull/236) by @gbhrdt to this repo, would very much like to no longer include jQuery v1.11.10 in my Meteor bundle. Thank you!