### PR TITLE
Updated all console.log mentions of Kadira to Meteor APM.

### DIFF
--- a/lib/hijack/instrument.js
+++ b/lib/hijack/instrument.js
@@ -39,5 +39,5 @@ Kadira._startInstrumenting = function(callback) {
 // One reason for this is to call `setLables()` function
 // Otherwise, CPU profile can't see all our custom labeling
 Kadira._startInstrumenting(function() {
-  console.log('Kadira: completed instrumenting the app')
+  console.log('Meteor APM: completed instrumenting the app')
 });

--- a/lib/kadira.js
+++ b/lib/kadira.js
@@ -88,15 +88,15 @@ Kadira.connect = function(appId, appSecret, options) {
     Kadira.coreApi._checkAuth()
       .then(function() {
         logger('connected to app: ', appId);
-        console.log('Kadira: Successfully connected');
+        console.log('Meteor APM: Successfully connected');
         Kadira._sendAppStats();
         Kadira._schedulePayloadSend();
       })
       .catch(function(err) {
-        console.log('Kadira: authentication failed - check your appId & appSecret')
+        console.log('Meteor APM: authentication failed - check your appId & appSecret')
       });
   } else {
-    throw new Error('Kadira: required appId and appSecret');
+    throw new Error('Meteor APM: required appId and appSecret');
   }
 
   // start tracking errors
@@ -171,7 +171,7 @@ Kadira._sendPayload = function (callback) {
     Kadira.coreApi.sendData(payload)
     .then(callback)
     .catch(function(err) {
-      console.log('Kadira Error:', err.message);
+      console.log('Meteor APM Error:', err.message);
       callback();
     });
   }).run();


### PR DESCRIPTION
This update makes the console.log output say "Meteor APM..." versus "Kadira..." for apps using Meteor APM.