### PR TITLE
Remove meteorhacks:meteorx dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### v3.2.0
+
+* Remove dependency on `meteorhacks:meteorx`.
+  [PR #7](https://github.com/meteor/meteor-apm-agent/pull/7)
+
+* Use the Meteor core `ecmascript` package.
+
+* Update `api.versionFrom` to Meteor 1.7.
+
 ### v3.1.1
 
 * Use `Object.create(null)` rather than object initializer notation when

--- a/lib/hijack/db.js
+++ b/lib/hijack/db.js
@@ -1,3 +1,8 @@
+import {
+  MongoConnection,
+  MongoCursor,
+} from "./meteorx.js";
+
 // This hijack is important to make sure, collections created before
 // we hijack dbOps, even gets tracked.
 //  Meteor does not simply expose MongoConnection object to the client
@@ -26,7 +31,7 @@ MongoInternals.RemoteCollectionDriver.prototype.open = function open(name) {
 };
 
 hijackDBOps = function hijackDBOps() {
-  var mongoConnectionProto = MeteorX.MongoConnection.prototype;
+  var mongoConnectionProto = MongoConnection.prototype;
   //findOne is handled by find - so no need to track it
   //upsert is handles by update
   ['find', 'update', 'remove', 'insert', '_ensureIndex', '_dropIndex'].forEach(function(func) {
@@ -94,7 +99,7 @@ hijackDBOps = function hijackDBOps() {
     };
   });
 
-  var cursorProto = MeteorX.MongoCursor.prototype;
+  var cursorProto = MongoCursor.prototype;
   ['forEach', 'map', 'fetch', 'count', 'observeChanges', 'observe', 'rewind'].forEach(function(type) {
     var originalFunc = cursorProto[type];
     cursorProto[type] = function() {

--- a/lib/hijack/instrument.js
+++ b/lib/hijack/instrument.js
@@ -1,3 +1,12 @@
+import {
+  MongoOplogDriver,
+  MongoPollingDriver,
+  Multiplexer,
+  Server,
+  Session,
+  Subscription,
+} from "./meteorx.js";
+
 var logger = Npm.require('debug')('kadira:hijack:instrument');
 
 var instrumented = false;
@@ -9,22 +18,22 @@ Kadira._startInstrumenting = function(callback) {
 
   instrumented = true;
   wrapStringifyDDP()
-  MeteorX.onReady(function() {
-    //instrumenting session
-    wrapServer(MeteorX.Server.prototype);
-    wrapSession(MeteorX.Session.prototype);
-    wrapSubscription(MeteorX.Subscription.prototype);
+  Meteor.startup(async function () {
+    wrapServer(Server.prototype);
 
-    if(MeteorX.MongoOplogDriver) {
-      wrapOplogObserveDriver(MeteorX.MongoOplogDriver.prototype);
+    wrapSession(Session.prototype);
+    wrapSubscription(Subscription.prototype);
+
+    if (MongoOplogDriver) {
+      wrapOplogObserveDriver(MongoOplogDriver.prototype);
     }
 
-    if(MeteorX.MongoPollingDriver) {
-      wrapPollingObserveDriver(MeteorX.MongoPollingDriver.prototype);
+    if (MongoPollingDriver) {
+      wrapPollingObserveDriver(MongoPollingDriver.prototype);
     }
 
-    if(MeteorX.Multiplexer) {
-      wrapMultiplexer(MeteorX.Multiplexer.prototype);
+    if (Multiplexer) {
+      wrapMultiplexer(Multiplexer.prototype);
     }
 
     wrapForCountingObservers();

--- a/lib/hijack/meteorx.js
+++ b/lib/hijack/meteorx.js
@@ -1,0 +1,100 @@
+// Various tricks for accessing "private" Meteor APIs borrowed from the
+// now-unmaintained meteorhacks:meteorx package.
+
+export const Server = Meteor.server.constructor;
+
+function getSession() {
+  const fakeSocket = {
+    send() {},
+    close() {},
+    headers: []
+  };
+
+  const server = Meteor.default_server;
+
+  server._handleConnect(fakeSocket, {
+    msg: "connect",
+    version: "pre1",
+    support: ["pre1"]
+  });
+
+  const session = fakeSocket._meteorSession;
+
+  server._removeSession(session);
+
+  return session;
+}
+
+const session = getSession();
+export const Session = session.constructor;
+
+const collection = new Mongo.Collection("__dummy_coll_" + Random.id());
+collection.findOne();
+const cursor = collection.find();
+export const MongoCursor = cursor.constructor;
+
+function getMultiplexer(cursor) {
+  const handle = cursor.observeChanges({
+    added() {}
+  });
+  handle.stop();
+  return handle._multiplexer;
+}
+
+export const Multiplexer = getMultiplexer(cursor).constructor;
+
+export const MongoConnection =
+  MongoInternals.defaultRemoteCollectionDriver().mongo.constructor;
+
+function getSubscription(session) {
+  const subId = Random.id();
+
+  session._startSubscription(function () {
+    this.ready();
+  }, subId, [], "__dummy_pub_" + Random.id());
+
+  const subscription = session._namedSubs instanceof Map
+    ? session._namedSubs.get(subId)
+    : session._namedSubs[subId];
+
+  session._stopSubscription(subId);
+
+  return subscription;
+}
+
+export const Subscription = getSubscription(session).constructor;
+
+function getObserverDriver(cursor) {
+  const multiplexer = getMultiplexer(cursor);
+  return multiplexer && multiplexer._observeDriver || null;
+}
+
+function getMongoOplogDriver() {
+  const driver = getObserverDriver(cursor);
+  let MongoOplogDriver = driver && driver.constructor || null;
+  if (MongoOplogDriver &&
+      typeof MongoOplogDriver.cursorSupported !== "function") {
+    return null;
+  }
+  return MongoOplogDriver;
+}
+
+export const MongoOplogDriver = getMongoOplogDriver();
+
+function getMongoPollingDriver() {
+  const cursor = collection.find({}, {
+    limit: 20,
+    _disableOplog: true,
+  });
+
+  const driver = getObserverDriver(cursor);
+
+  // verify observer driver is a polling driver
+  if (driver && typeof driver.constructor.cursorSupported === "undefined") {
+    return driver.constructor;
+  }
+
+  return null;
+}
+
+export const MongoPollingDriver = getMongoPollingDriver();

--- a/lib/hijack/set_labels.js
+++ b/lib/hijack/set_labels.js
@@ -1,91 +1,98 @@
+import {
+  Session,
+  Multiplexer,
+  MongoConnection,
+  MongoCursor,
+} from "./meteorx.js";
+
 setLabels = function () {
   // name Session.prototype.send
-  var originalSend = MeteorX.Session.prototype.send;
-  MeteorX.Session.prototype.send = function kadira_Session_send (msg) {
+  var originalSend = Session.prototype.send;
+  Session.prototype.send = function kadira_Session_send (msg) {
     return originalSend.call(this, msg);
   }
 
   // name Multiplexer initial adds
-  var originalSendAdds = MeteorX.Multiplexer.prototype._sendAdds;
-  MeteorX.Multiplexer.prototype._sendAdds = function kadira_Multiplexer_sendAdds (handle) {
+  var originalSendAdds = Multiplexer.prototype._sendAdds;
+  Multiplexer.prototype._sendAdds = function kadira_Multiplexer_sendAdds (handle) {
     return originalSendAdds.call(this, handle);
   }
 
   // name MongoConnection insert
-  var originalMongoInsert = MeteorX.MongoConnection.prototype._insert;
-  MeteorX.MongoConnection.prototype._insert = function kadira_MongoConnection_insert (coll, doc, cb) {
+  var originalMongoInsert = MongoConnection.prototype._insert;
+  MongoConnection.prototype._insert = function kadira_MongoConnection_insert (coll, doc, cb) {
     return originalMongoInsert.call(this, coll, doc, cb);
   }
 
   // name MongoConnection update
-  var originalMongoUpdate = MeteorX.MongoConnection.prototype._update;
-  MeteorX.MongoConnection.prototype._update = function kadira_MongoConnection_update (coll, selector, mod, options, cb) {
+  var originalMongoUpdate = MongoConnection.prototype._update;
+  MongoConnection.prototype._update = function kadira_MongoConnection_update (coll, selector, mod, options, cb) {
     return originalMongoUpdate.call(this, coll, selector, mod, options, cb);
   }
 
   // name MongoConnection remove
-  var originalMongoRemove = MeteorX.MongoConnection.prototype._remove;
-  MeteorX.MongoConnection.prototype._remove = function kadira_MongoConnection_remove (coll, selector, cb) {
+  var originalMongoRemove = MongoConnection.prototype._remove;
+  MongoConnection.prototype._remove = function kadira_MongoConnection_remove (coll, selector, cb) {
     return originalMongoRemove.call(this, coll, selector, cb);
   }
 
   // name Pubsub added
-  var originalPubsubAdded = MeteorX.Session.prototype.sendAdded;
-  MeteorX.Session.prototype.sendAdded = function kadira_Session_sendAdded (coll, id, fields) {
+  var originalPubsubAdded = Session.prototype.sendAdded;
+  Session.prototype.sendAdded = function kadira_Session_sendAdded (coll, id, fields) {
     return originalPubsubAdded.call(this, coll, id, fields);
   }
 
   // name Pubsub changed
-  var originalPubsubChanged = MeteorX.Session.prototype.sendChanged;
-  MeteorX.Session.prototype.sendChanged = function kadira_Session_sendChanged (coll, id, fields) {
+  var originalPubsubChanged = Session.prototype.sendChanged;
+  Session.prototype.sendChanged = function kadira_Session_sendChanged (coll, id, fields) {
     return originalPubsubChanged.call(this, coll, id, fields);
   }
 
   // name Pubsub removed
-  var originalPubsubRemoved = MeteorX.Session.prototype.sendRemoved;
-  MeteorX.Session.prototype.sendRemoved = function kadira_Session_sendRemoved (coll, id) {
+  var originalPubsubRemoved = Session.prototype.sendRemoved;
+  Session.prototype.sendRemoved = function kadira_Session_sendRemoved (coll, id) {
     return originalPubsubRemoved.call(this, coll, id);
   }
 
   // name MongoCursor forEach
-  var originalCursorForEach = MeteorX.MongoCursor.prototype.forEach;
-  MeteorX.MongoCursor.prototype.forEach = function kadira_Cursor_forEach () {
+  var originalCursorForEach = MongoCursor.prototype.forEach;
+  MongoCursor.prototype.forEach = function kadira_Cursor_forEach () {
     return originalCursorForEach.apply(this, arguments);
   }
 
   // name MongoCursor map
-  var originalCursorMap = MeteorX.MongoCursor.prototype.map;
-  MeteorX.MongoCursor.prototype.map = function kadira_Cursor_map () {
+  var originalCursorMap = MongoCursor.prototype.map;
+  MongoCursor.prototype.map = function kadira_Cursor_map () {
     return originalCursorMap.apply(this, arguments);
   }
 
   // name MongoCursor fetch
-  var originalCursorFetch = MeteorX.MongoCursor.prototype.fetch;
-  MeteorX.MongoCursor.prototype.fetch = function kadira_Cursor_fetch () {
+  var originalCursorFetch = MongoCursor.prototype.fetch;
+  MongoCursor.prototype.fetch = function kadira_Cursor_fetch () {
     return originalCursorFetch.apply(this, arguments);
   }
 
   // name MongoCursor count
-  var originalCursorCount = MeteorX.MongoCursor.prototype.count;
-  MeteorX.MongoCursor.prototype.count = function kadira_Cursor_count () {
+  var originalCursorCount = MongoCursor.prototype.count;
+  MongoCursor.prototype.count = function kadira_Cursor_count () {
     return originalCursorCount.apply(this, arguments);
   }
 
   // name MongoCursor observeChanges
-  var originalCursorObserveChanges = MeteorX.MongoCursor.prototype.observeChanges;
-  MeteorX.MongoCursor.prototype.observeChanges = function kadira_Cursor_observeChanges () {
+  var originalCursorObserveChanges = MongoCursor.prototype.observeChanges;
+  MongoCursor.prototype.observeChanges = function kadira_Cursor_observeChanges () {
     return originalCursorObserveChanges.apply(this, arguments);
   }
 
   // name MongoCursor observe
-  var originalCursorObserve = MeteorX.MongoCursor.prototype.observe;
-  MeteorX.MongoCursor.prototype.observe = function kadira_Cursor_observe () {
+  var originalCursorObserve = MongoCursor.prototype.observe;
+  MongoCursor.prototype.observe = function kadira_Cursor_observe () {
     return originalCursorObserve.apply(this, arguments);
   }
 
   // name MongoCursor rewind
-  var originalCursorRewind = MeteorX.MongoCursor.prototype.rewind;
-  MeteorX.MongoCursor.prototype.rewind = function kadira_Cursor_rewind () {
+  var originalCursorRewind = MongoCursor.prototype.rewind;
+  MongoCursor.prototype.rewind = function kadira_Cursor_rewind () {
     return originalCursorRewind.apply(this, arguments);
   }
 

--- a/lib/hijack/wrap_observers.js
+++ b/lib/hijack/wrap_observers.js
@@ -1,3 +1,5 @@
+import { MongoConnection } from "./meteorx.js";
+
 wrapOplogObserveDriver = function(proto) {
   // Track the polled documents. This is reflect to the RAM size and
   // for the CPU usage directly
@@ -156,7 +158,7 @@ wrapMultiplexer = function(proto) {
 
 wrapForCountingObservers = function() {
   // to count observers
-  var mongoConnectionProto = MeteorX.MongoConnection.prototype;
+  var mongoConnectionProto = MongoConnection.prototype;
   var originalObserveChanges = mongoConnectionProto._observeChanges;
   mongoConnectionProto._observeChanges = function(cursorDescription, ordered, callbacks) {
     var ret = originalObserveChanges.call(this, cursorDescription, ordered, callbacks);

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   "summary": "Performance Monitoring for Meteor",
-  "version": "3.1.2",
+  "version": "3.2.0-rc.0",
   "git": "https://github.com/meteor/meteor-apm-agent.git",
   "name": "mdg:meteor-apm-agent"
 });

--- a/package.js
+++ b/package.js
@@ -86,8 +86,8 @@ Package.on_test(function(api) {
 });
 
 function configurePackage(api) {
-  if(api.versionsFrom) {
-    api.versionsFrom('METEOR@1.2');
+  if (api.versionsFrom) {
+    api.versionsFrom('METEOR@1.7');
     api.use('meteorhacks:zones@1.2.1', {weak: true});
   }
 

--- a/package.js
+++ b/package.js
@@ -88,14 +88,23 @@ Package.on_test(function(api) {
 function configurePackage(api) {
   if(api.versionsFrom) {
     api.versionsFrom('METEOR@1.2');
-    api.use('meteorhacks:meteorx@1.4.1', ['server']);
     api.use('meteorhacks:zones@1.2.1', {weak: true});
   }
 
   api.use([
-    'minimongo', 'livedata', 'mongo-livedata', 'ejson', 'ddp-common',
-    'underscore', 'http', 'email', 'random'
+    'ecmascript',
+    'mongo',
+    'minimongo',
+    'livedata',
+    'mongo-livedata',
+    'ejson',
+    'ddp-common',
+    'underscore',
+    'http',
+    'email',
+    'random',
   ], ['server']);
+
   api.use(['underscore', 'random', 'http', 'localstorage'], ['client']);
 
   // common before

--- a/tests/hijack/set_labels.js
+++ b/tests/hijack/set_labels.js
@@ -1,14 +1,21 @@
+import {
+  Session,
+  MongoCursor,
+  MongoConnection,
+  Multiplexer,
+} from "../../lib/hijack/meteorx.js";
+
 Tinytest.add(
   'CPU Profiler - set labels - Session.prototype.send',
   function (test) {
-    test.equal(MeteorX.Session.prototype.send.name, 'kadira_Session_send');
+    test.equal(Session.prototype.send.name, 'kadira_Session_send');
   }
 );
 
 Tinytest.add(
   'CPU Profiler - set labels - MongoCursor methods',
   function (test) {
-    var cursorProto = MeteorX.MongoCursor.prototype;
+    var cursorProto = MongoCursor.prototype;
     ['forEach', 'map', 'fetch', 'count', 'observeChanges', 'observe', 'rewind']
     .forEach(function (name) {
       test.equal(cursorProto[name].name, 'kadira_Cursor_'+name);
@@ -19,7 +26,7 @@ Tinytest.add(
 Tinytest.add(
   'CPU Profiler - set labels - Multiplexer.prototype._sendAdds',
   function (test) {
-    var name = MeteorX.Multiplexer.prototype._sendAdds.name;
+    var name = Multiplexer.prototype._sendAdds.name;
     test.equal(name, 'kadira_Multiplexer_sendAdds');
   }
 );
@@ -27,7 +34,7 @@ Tinytest.add(
 Tinytest.add(
   'CPU Profiler - set labels - MongoConnection methods',
   function (test) {
-    var cursorProto = MeteorX.MongoConnection.prototype;
+    var cursorProto = MongoConnection.prototype;
     ['insert', 'update', 'remove'].forEach(function (name) {
       test.equal(cursorProto['_'+name].name, 'kadira_MongoConnection_'+name);
     });
@@ -37,7 +44,7 @@ Tinytest.add(
 Tinytest.add(
   'CPU Profiler - set labels - Session sends',
   function (test) {
-    var sessionProto = MeteorX.Session.prototype;
+    var sessionProto = Session.prototype;
     ['sendAdded', 'sendChanged', 'sendRemoved'].forEach(function (name) {
       test.equal(sessionProto[name].name, 'kadira_Session_'+name);
     });


### PR DESCRIPTION
This PR brings the relevant bits of [`meteorhacks:meteorx`](https://github.com/meteorhacks/meteorx) into the `mdg:meteor-apm-agent` package, so that [various issues](https://github.com/meteorhacks/meteorx/pull/9) can be fixed without forking or continuing to maintain `meteorhacks:meteorx`.

Related:
https://github.com/meteor/meteor/issues/10337#issuecomment-441717091
https://github.com/meteorhacks/meteorx/issues/8
https://github.com/meteorhacks/meteorx/pull/9
https://github.com/abecks/meteor-fast-render/issues/25