### PR TITLE
Tolerate Map and Set in ddp-server data structures.

### DIFF
--- a/lib/hijack/meteorx.js
+++ b/lib/hijack/meteorx.js
@@ -1,6 +1,8 @@
 // Various tricks for accessing "private" Meteor APIs borrowed from the
 // now-unmaintained meteorhacks:meteorx package.
 
+import { get } from "../utils.js";
+
 export const Server = Meteor.server.constructor;
 
 function getSession() {
@@ -53,9 +55,7 @@ function getSubscription(session) {
     this.ready();
   }, subId, [], "__dummy_pub_" + Random.id());
 
-  const subscription = session._namedSubs instanceof Map
-    ? session._namedSubs.get(subId)
-    : session._namedSubs[subId];
+  const subscription = get(session._namedSubs, subId);
 
   session._stopSubscription(subId);
 

--- a/lib/models/pubsub.js
+++ b/lib/models/pubsub.js
@@ -1,5 +1,7 @@
 var logger = Npm.require('debug')('kadira:pubsub');
 
+import { size, each, get } from "../utils.js";
+
 PubsubModel = function() {
   this.metricsByMinute = Object.create(null);
   this.subscriptions = Object.create(null);
@@ -162,11 +164,10 @@ PubsubModel.prototype._getSubscriptionInfo = function() {
   var totalObservers = Object.create(null);
   var cachedObservers = Object.create(null);
 
-  for(var sessionId in Meteor.default_server.sessions) {
-    var session = Meteor.default_server.sessions[sessionId];
-    _.each(session._namedSubs, countSubData);
-    _.each(session._universalSubs, countSubData);
-  }
+  each(Meteor.default_server.sessions, session => {
+    each(session._namedSubs, countSubData);
+    each(session._universalSubs, countSubData);
+  });
 
   var avgObserverReuse = Object.create(null);
   _.each(totalObservers, function(value, publication) {
@@ -193,9 +194,9 @@ PubsubModel.prototype._getSubscriptionInfo = function() {
 
   function countDocuments (sub, publication) {
     activeDocs[publication] = activeDocs[publication] || 0;
-    for(collectionName in sub._documents) {
-      activeDocs[publication] += _.keys(sub._documents[collectionName]).length;
-    }
+    each(sub._documents, document => {
+      activeDocs[publication] += size(document);
+    });
   }
 
   function countObservers(sub, publication) {
@@ -261,10 +262,10 @@ PubsubModel.prototype.incrementHandleCount = function(trace, isCached) {
   var publicationName = this._getPublicationName(trace.name);
   var publication = this._getMetrics(timestamp, publicationName);
 
-  var session = Meteor.default_server.sessions[trace.session];
-  if(session) {
-    var sub = session._namedSubs[trace.id];
-    if(sub) {
+  var session = get(Meteor.default_server.sessions, trace.session);
+  if (session) {
+    var sub = get(session._namedSubs, trace.id);
+    if (sub) {
       sub._totalObservers = sub._totalObservers || 0;
       sub._cachedObservers = sub._cachedObservers || 0;
     }

--- a/lib/models/system.js
+++ b/lib/models/system.js
@@ -1,3 +1,5 @@
+import { size } from "../utils.js";
+
 var os = Npm.require('os');
 var usage = Npm.require('pidusage');
 var EventLoopMonitor = Npm.require('evloop-monitor');
@@ -21,7 +23,7 @@ SystemModel.prototype.buildPayload = function() {
   metrics.startTime = Kadira.syncedDate.syncTime(this.startTime);
   metrics.endTime = Kadira.syncedDate.syncTime(now);
 
-  metrics.sessions = _.keys(Meteor.default_server.sessions).length;
+  metrics.sessions = size(Meteor.default_server.sessions);
   metrics.memory = process.memoryUsage().rss / (1024*1024);
   metrics.newSessions = this.newSessions;
   this.newSessions = 0;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,29 @@
 var Fiber = Npm.require('fibers');
 
+export function size(collection) {
+  if (collection instanceof Map ||
+      collection instanceof Set) {
+    return collection.size;
+  }
+  return _.size(collection);
+}
+
+export function each(collection, callback) {
+  if (collection instanceof Map ||
+      collection instanceof Set) {
+    collection.forEach(callback);
+  } else {
+    _.each(collection, callback);
+  }
+}
+
+export function get(collection, key) {
+  if (collection instanceof Map) {
+    return collection.get(key);
+  }
+  return collection[key];
+}
+
 HaveAsyncCallback = function(args) {
   var lastArg = args[args.length -1];
   return (typeof lastArg) == 'function';

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   "summary": "Performance Monitoring for Meteor",
-  "version": "3.2.1",
+  "version": "3.2.2-rc.0",
   "git": "https://github.com/meteor/meteor-apm-agent.git",
   "name": "mdg:meteor-apm-agent"
 });


### PR DESCRIPTION
PR #7 partially accommodated the changes introduced by https://github.com/meteor/meteor/pull/10053, but this commit seeks to address the rest of the relevant changes, which mostly involve converting`{}` to `Map` or `Set`.

Although these changes to `ddp-server` predated Meteor 1.8, the `ddp-server` version was not bumped in Meteor 1.8 or 1.8.0.2 (https://github.com/meteor/meteor/issues/10357), so Meteor 1.8.1 will be the first time `ddp-server` is forced to update.