### PR TITLE
fix #10078 - error logged as [object Object]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .build*
 smart.lock
 versions.json
+*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v3.2.5
+
+* Fix log `[object Object]` issue. See [meteor#10078](https://github.com/meteor/meteor/issues/10078).Thx @zodern.
+
 ### v3.2.0
 
 * Remove dependency on `meteorhacks:meteorx`.

--- a/lib/hijack/error.js
+++ b/lib/hijack/error.js
@@ -58,7 +58,10 @@ TrackMeteorDebug = function () {
     // We've changed `stack` into an object at method and sub handlers so we can
     // ignore them here. These errors are already tracked so don't track again.
     if(stack && stack.stack) {
-      stack = stack.stack
+      stack = stack.stack;
+      // Restore so origionalMeteorDebug shows the stack as a string instead as
+      // an object
+      arguments[1] = stack;
     } else {
       // only send to the server, if only connected to kadira
       if(Kadira.connected) {

--- a/lib/hijack/wrap_session.js
+++ b/lib/hijack/wrap_session.js
@@ -172,7 +172,9 @@ function wrapMethodHanderForErrors(name, originalHandler, methodMap) {
         // We also track Meteor.debug errors and want to stop
         // tracking this error. That's why we do this
         // See Meteor.debug error tracking code for more
-        ex.stack = {stack: ex.stack, source: 'method'};
+        if (Kadira.options.enableErrorTracking) {
+          ex.stack = {stack: ex.stack, source: 'method'};
+        }
         Kadira._getInfo().currentError = ex;
       }
       throw ex;

--- a/lib/hijack/wrap_subscription.js
+++ b/lib/hijack/wrap_subscription.js
@@ -61,7 +61,9 @@ wrapSubscription = function(subscriptionProto) {
       }
 
       // wrap error stack so Meteor._debug can identify and ignore it
-      err.stack = {stack: err.stack, source: 'subscription'};
+      if (Kadira.options.enableErrorTracking) {
+        err.stack = { stack: err.stack, source: "subscription" };
+      }
       originalError.call(this, err);
     }
   };

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   "summary": "Performance Monitoring for Meteor",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "git": "https://github.com/meteor/meteor-apm-agent.git",
   "name": "mdg:meteor-apm-agent"
 });


### PR DESCRIPTION
Fixes Meteor error logging to include stack trace when meteor-apm-agent package is used.
Source: https://github.com/meteor/meteor/issues/10078