### PR TITLE
Fix and setting to disable

### DIFF
--- a/lib/auto_connect.js
+++ b/lib/auto_connect.js
@@ -1,4 +1,12 @@
 Kadira._connectWithEnv = function() {
+  if (Meteor &&
+      Meteor.settings &&
+      Meteor.settings.packages &&
+      Meteor.settings.packages['mdg:meteor-apm-agent'] &&
+      Meteor.settings.packages['mdg:meteor-apm-agent'].isDisabled) {
+    console.log('Meteor APM: not connected because it was disabled in settings');
+    return;
+  }
   if(process.env.APM_APP_ID && process.env.APM_APP_SECRET && process.env.APM_OPTIONS_ENDPOINT) {
     var options = Kadira._parseEnv(process.env);
 

--- a/lib/docsize_cache.js
+++ b/lib/docsize_cache.js
@@ -16,7 +16,7 @@ DocSzCache.prototype.setPcpu = function (pcpu) {
 DocSzCache.prototype.getSize = function (coll, query, opts, data) {
   // If the dataset is null or empty we can't calculate the size
   // Do not process this data and return 0 as the document size.
-  if (!(data && (data.length || (data.size && data.size())))) {
+  if (!(data && (data.length || data.size))) {
     return 0;
   }
 


### PR DESCRIPTION
This PR fixes an issue in docsize_cache.js#19 where the data parameter can be either an Array or a Map, and a Map's size property is a number and not a function.

Also, it makes so the APM can be disabled with a setting in Meteor.settings.packages['mdg:meteor-apm-agent'].isDisabled