### PR TITLE
Update deprecated API

### DIFF
--- a/lib/hijack/meteorx.js
+++ b/lib/hijack/meteorx.js
@@ -12,7 +12,7 @@ function getSession() {
     headers: []
   };
 
-  const server = Meteor.default_server;
+  const server = Meteor.server;
 
   server._handleConnect(fakeSocket, {
     msg: "connect",

--- a/lib/hijack/wrap_session.js
+++ b/lib/hijack/wrap_session.js
@@ -141,8 +141,8 @@ wrapSession = function(sessionProto) {
 };
 
 // wrap existing method handlers for capturing errors
-_.each(Meteor.default_server.method_handlers, function(handler, name) {
-  wrapMethodHanderForErrors(name, handler, Meteor.default_server.method_handlers);
+_.each(Meteor.server.method_handlers, function(handler, name) {
+  wrapMethodHanderForErrors(name, handler, Meteor.server.method_handlers);
 });
 
 // wrap future method handlers for capturing errors

--- a/lib/models/pubsub.js
+++ b/lib/models/pubsub.js
@@ -164,7 +164,7 @@ PubsubModel.prototype._getSubscriptionInfo = function() {
   var totalObservers = Object.create(null);
   var cachedObservers = Object.create(null);
 
-  each(Meteor.default_server.sessions, session => {
+  each(Meteor.server.sessions, session => {
     each(session._namedSubs, countSubData);
     each(session._universalSubs, countSubData);
   });
@@ -262,7 +262,7 @@ PubsubModel.prototype.incrementHandleCount = function(trace, isCached) {
   var publicationName = this._getPublicationName(trace.name);
   var publication = this._getMetrics(timestamp, publicationName);
 
-  var session = get(Meteor.default_server.sessions, trace.session);
+  var session = get(Meteor.server.sessions, trace.session);
   if (session) {
     var sub = get(session._namedSubs, trace.id);
     if (sub) {

--- a/lib/models/system.js
+++ b/lib/models/system.js
@@ -23,7 +23,7 @@ SystemModel.prototype.buildPayload = function() {
   metrics.startTime = Kadira.syncedDate.syncTime(this.startTime);
   metrics.endTime = Kadira.syncedDate.syncTime(now);
 
-  metrics.sessions = size(Meteor.default_server.sessions);
+  metrics.sessions = size(Meteor.server.sessions);
   metrics.memory = process.memoryUsage().rss / (1024*1024);
   metrics.newSessions = this.newSessions;
   this.newSessions = 0;

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   "summary": "Performance Monitoring for Meteor",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "git": "https://github.com/meteor/meteor-apm-agent.git",
   "name": "mdg:meteor-apm-agent"
 });
@@ -17,12 +17,12 @@ var npmModules = {
 
 Npm.depends(npmModules);
 
-Package.on_use(function(api) {
+Package.onUse(function(api) {
   configurePackage(api);
   api.export(['Kadira']);
 });
 
-Package.on_test(function(api) {
+Package.onTest(function(api) {
   configurePackage(api);
   api.use([
     'tinytest',
@@ -30,12 +30,12 @@ Package.on_test(function(api) {
   ], ['client', 'server']);
 
   // common before
-  api.add_files([
+  api.addFiles([
     'tests/models/base_error.js'
   ], ['client', 'server']);
 
   // common server
-  api.add_files([
+  api.addFiles([
     'tests/utils.js',
     'tests/ntp.js',
     'tests/jobs.js',
@@ -68,7 +68,7 @@ Package.on_test(function(api) {
   ], 'server');
 
   // common client
-  api.add_files([
+  api.addFiles([
     'tests/client/utils.js',
     'tests/client/error_tracking.js',
     'tests/client/models/error.js',
@@ -78,7 +78,7 @@ Package.on_test(function(api) {
   ], 'client');
 
   // common after
-  api.add_files([
+  api.addFiles([
     'tests/common/default_error_filters.js',
     'tests/common/send.js'
   ], ['client', 'server']);
@@ -107,13 +107,13 @@ function configurePackage(api) {
   api.use(['underscore', 'random', 'http', 'localstorage'], ['client']);
 
   // common before
-  api.add_files([
+  api.addFiles([
     'lib/common/unify.js',
     'lib/models/base_error.js'
   ], ['client', 'server']);
 
   // only server
-  api.add_files([
+  api.addFiles([
     'lib/jobs.js',
     'lib/retry.js',
     'lib/utils.js',
@@ -147,7 +147,7 @@ function configurePackage(api) {
   ], 'server');
 
   // only client
-  api.add_files([
+  api.addFiles([
     'lib/retry.js',
     'lib/ntp.js',
     'lib/client/utils.js',
@@ -158,7 +158,7 @@ function configurePackage(api) {
     'lib/client/kadira.js'
   ], 'client');
 
-  api.add_files([
+  api.addFiles([
     // It's possible to remove this file after some since this just contains
     // a notice to the user.
     // Actual implementation is in the meteorhacks:kadira-profiler package
@@ -166,7 +166,7 @@ function configurePackage(api) {
   ], 'client');
 
   // common after
-  api.add_files([
+  api.addFiles([
     'lib/common/default_error_filters.js',
     'lib/common/send.js'
   ], ['client', 'server']);

--- a/tests/_helpers/helpers.js
+++ b/tests/_helpers/helpers.js
@@ -124,7 +124,7 @@ CloseClient = function(client) {
   client.disconnect();
   var f = new Future();
   function checkClientExtence(sessionId) {
-    var sessionExists = Meteor.default_server.sessions[sessionId];
+    var sessionExists = Meteor.server.sessions[sessionId];
     if(sessionExists) {
       setTimeout(function() {
         checkClientExtence(sessionId);

--- a/tests/models/system.js
+++ b/tests/models/system.js
@@ -160,6 +160,6 @@ function sendConnectMessage (options) {
     socket.headers['x-forwarded-for'] = options.forwardedAddress;
   if(options.sessionId)
     message.session = options.sessionId;
-  Meteor.default_server._handleConnect(socket, message);
+  Meteor.server._handleConnect(socket, message);
   return socket._meteorSession;
 }


### PR DESCRIPTION
APM uses API that has been deprecated since Meteor 1.0 and are finally being removed in Meteor 2.3. This fixes the API that I have found.